### PR TITLE
Dialog Signal Hotfix

### DIFF
--- a/Games/quantum-navigator/QuantumNavigator/Dialog-System-Example/scripts/dialog_player.gd
+++ b/Games/quantum-navigator/QuantumNavigator/Dialog-System-Example/scripts/dialog_player.gd
@@ -111,7 +111,7 @@ func _get_next_node():
 		get_tree().paused = false;
 		_Anim.stop()
 		_Anim.play("dialog_disappear")
-		yield(_Anim, "animation_finished")
+		yield(get_tree(), "idle_frame")
 		_emit_dialog_open_signal(false)
 
 


### PR DESCRIPTION
Shortens yield to a frame to prevent errors that occur when going through dialog too quickly