### PR TITLE
(chore) add .gitignore to quantum-navigator

### DIFF
--- a/Games/quantum-navigator/QuantumNavigator/.gitignore
+++ b/Games/quantum-navigator/QuantumNavigator/.gitignore
@@ -1,0 +1,11 @@
+# Godot-specific ignores
+.import/
+export.cfg
+export_presets.cfg
+
+# Imported translations (automatically generated from CSV files)
+*.translation
+
+# Mono-specific ignores
+.mono/
+data_*/


### PR DESCRIPTION
adds .gitignore to quantum-navigator directory to avoid merging unneeded files in the future